### PR TITLE
Fix: Make Show additional properties button functional

### DIFF
--- a/packages/api-reference/index.html
+++ b/packages/api-reference/index.html
@@ -95,6 +95,10 @@
             title: 'OpenStatus',
             url: 'https://api.openstatus.dev/v1/openapi',
           },
+          {
+            title: 'Reproducing Issue',
+            url: 'testopenapi.json',
+          },
         ],
         persistAuth: true,
         // Avoid CORS issues

--- a/packages/api-reference/src/components/Content/Schema/Schema.vue
+++ b/packages/api-reference/src/components/Content/Schema/Schema.vue
@@ -108,7 +108,16 @@ const schema = computed(() => {
 })
 
 const shouldShowToggle = computed(() => {
-  if (props.noncollapsible || props.level === 0) {
+  if (props.noncollapsible) {
+    return false
+  }
+
+  // Allow toggle for additionalProperties even at level 0
+  if (props.additionalProperties) {
+    return true
+  }
+
+  if (props.level === 0) {
     return false
   }
 

--- a/packages/api-reference/testopenapi.json
+++ b/packages/api-reference/testopenapi.json
@@ -1,0 +1,144 @@
+{
+  "openapi": "3.0.1",
+  "paths": {
+    "/Test": {
+      "post": {
+        "summary": "Test",
+        "operationId": "Test",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/TestRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "No Content"
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "TestRequest": {
+        "required": [
+          "A",
+          "B",
+          "C"
+        ],
+        "type": "object",
+        "properties": {
+          "A": {
+            "maxLength": 50,
+            "type": "string"
+          },
+          "B": {
+            "maxLength": 50,
+            "type": "string"
+          },
+          "C": {
+            "maxLength": 50,
+            "type": "string"
+          },
+          "D": {
+            "maxLength": 50,
+            "type": "string"
+          },
+          "E": {
+            "maxLength": 50,
+            "type": "string"
+          },
+          "F": {
+            "maxLength": 50,
+            "type": "string"
+          },
+          "G": {
+            "maxLength": 50,
+            "type": "string"
+          },
+          "H": {
+            "maxLength": 50,
+            "type": "string"
+          },
+          "I": {
+            "maxLength": 50,
+            "type": "string"
+          },
+          "J": {
+            "maxLength": 50,
+            "type": "string"
+          },
+          "K": {
+            "maxLength": 50,
+            "type": "string"
+          },
+          "L": {
+            "maxLength": 50,
+            "type": "string"
+          },
+          "M": {
+            "maxLength": 50,
+            "type": "string"
+          },
+          "N": {
+            "maxLength": 50,
+            "type": "string"
+          },
+          "O": {
+            "maxLength": 50,
+            "type": "string"
+          },
+          "P": {
+            "maxLength": 50,
+            "type": "string"
+          },
+          "Q": {
+            "maxLength": 50,
+            "type": "string"
+          },
+          "R": {
+            "maxLength": 50,
+            "type": "string"
+          },
+          "S": {
+            "maxLength": 50,
+            "type": "string"
+          },
+          "T": {
+            "maxLength": 50,
+            "type": "string"
+          },
+          "U": {
+            "maxLength": 50,
+            "type": "string"
+          },
+          "V": {
+            "maxLength": 50,
+            "type": "string"
+          },
+          "W": {
+            "maxLength": 50,
+            "type": "string"
+          },
+          "X": {
+            "maxLength": 50,
+            "type": "string"
+          },
+          "Y": {
+            "maxLength": 50,
+            "type": "string"
+          },
+          "Z": {
+            "maxLength": 50,
+            "type": "string"
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
Fixed the broken Show additional properties button that appears when schemas have more than 12 properties. The button was visible but non-functional - clicking it did nothing, and all properties were displayed regardless of the button state.

## Problem
When rendering schemas with many properties, the API Reference uses progressive disclosure to improve readability. However, the toggle button was appearing but completely non-functional. All properties displayed on page load, defeating the entire purpose of progressive disclosure.

## Root Cause
The shouldShowToggle computed property in Schema.vue was returning false for schemas with additionalProperties prop at level 0. This caused the DisclosurePanel to use static=true, which makes it always visible and ignores the disclosure button state.

## Solution
Modified the shouldShowToggle logic to explicitly allow toggles for additionalProperties even at level 0.

## Changes Made
- Schema.vue: Updated shouldShowToggle computed property to handle additionalProperties case
- testopenapi.json: Created test specification with 26 properties to reproduce the bug
- index.html: Added test spec to sources dropdown for manual testing

## Testing
Manual testing confirms button now properly shows and hides additional properties.


## Demo Loom Video 
https://www.loom.com/share/58f6888bab05485a973416058353a972?sid=9ca8ed01-1715-43d6-9db5-79090046e90e 

## Manual Testing Steps
1. Run pnpm dev:reference
2. Navigate to http://localhost:5174/
3. Select Reproducing Issue from dropdown
4. Click on POST /Test endpoint
5. Observe Request Body section - Properties A-L visible, M-Z hidden behind toggle button
6. Click button to reveal M-Z, click again to hide

